### PR TITLE
test(reader): add parsing infrastructure coverage

### DIFF
--- a/src/lib/Reader/JsonNodeHelper.cs
+++ b/src/lib/Reader/JsonNodeHelper.cs
@@ -16,7 +16,7 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
             var scalarNode = node is JsonValue value ? value : throw new OpenApiException($"Expected scalar value.");
 
-            return Convert.ToString(scalarNode?.GetValue<object>(), CultureInfo.InvariantCulture);
+            return Convert.ToString(scalarNode.GetValue<object>(), CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/lib/Reader/OverlayYamlReader.cs
+++ b/src/lib/Reader/OverlayYamlReader.cs
@@ -93,7 +93,7 @@ public class OverlayYamlReader : IOverlayReader
     {
         var yamlStream = new YamlStream();
         yamlStream.Load(input);
-        return yamlStream is { Documents.Count: > 0 }
+        return yamlStream.Documents.Count > 0
             ? yamlStream.Documents[0].ToJsonNode()
             : throw new InvalidOperationException("No documents found in the YAML stream.");
     }

--- a/src/lib/Reader/ParseNodes/ListNode.cs
+++ b/src/lib/Reader/ParseNodes/ListNode.cs
@@ -23,11 +23,6 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
         public override List<T> CreateList<T>(Func<MapNode, T> map)
         {
-            if (_nodeList == null)
-            {
-                throw new OverlayReaderException($"Expected list while parsing {typeof(T).Name}");
-            }
-
             var list = _nodeList
                 .OfType<JsonObject>()
                 .Select(n => map(new MapNode(Context, n)))
@@ -48,11 +43,6 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
         public override List<T> CreateSimpleList<T>(Func<ValueNode, T> map)
         {
-            if (_nodeList == null)
-            {
-                throw new OverlayReaderException($"Expected list while parsing {typeof(T).Name}");
-            }
-
             return _nodeList.OfType<JsonNode>().Select(n => map(new(Context, n))).ToList();
         }
 

--- a/src/lib/Reader/ParseNodes/MapNode.cs
+++ b/src/lib/Reader/ParseNodes/MapNode.cs
@@ -49,8 +49,7 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
         public override Dictionary<string, T> CreateMap<T>(Func<MapNode, T> map)
         {
-            var jsonMap = _node ?? throw new OverlayReaderException($"Expected map while parsing {typeof(T).Name}", Context);
-            var nodes = jsonMap.Select(
+            var nodes = _node.Select(
                 n =>
                 {
 
@@ -79,8 +78,7 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
         public override Dictionary<string, T> CreateSimpleMap<T>(Func<ValueNode, T> map)
         {
-            var jsonMap = _node ?? throw new OverlayReaderException($"Expected map while parsing {typeof(T).Name}", Context);
-            var nodes = jsonMap.Select(
+            var nodes = _node.Select(
                 n =>
                 {
                     var key = n.Key;
@@ -103,9 +101,7 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
 
         public override Dictionary<string, HashSet<T>> CreateArrayMap<T>(Func<ValueNode, T> map)
         {
-            var jsonMap = _node ?? throw new OverlayReaderException($"Expected map while parsing {typeof(T).Name}", Context);
-
-            var nodes = jsonMap.Select(n =>
+            var nodes = _node.Select(n =>
             {
                 var key = n.Key;
                 try
@@ -188,15 +184,11 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
         public string? GetScalarValue(ValueNode key)
         {
             var keyValue = key.GetScalarValue();
-            if (keyValue is not null)
-            {
-                var scalarNode = _node[keyValue] is JsonValue jsonValue
-                        ? jsonValue
-                        : throw new OverlayReaderException($"Expected scalar while parsing {key.GetScalarValue()}", Context);
+            var scalarNode = _node[keyValue] is JsonValue jsonValue
+                    ? jsonValue
+                    : throw new OverlayReaderException($"Expected scalar while parsing {key.GetScalarValue()}", Context);
 
-                return Convert.ToString(scalarNode?.GetValue<object>(), CultureInfo.InvariantCulture);
-            }
-            return null;
+            return Convert.ToString(scalarNode.GetValue<object>(), CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/lib/Reader/ParseNodes/ValueNode.cs
+++ b/src/lib/Reader/ParseNodes/ValueNode.cs
@@ -26,8 +26,7 @@ namespace BinkyLabs.OpenApi.Overlays.Reader
         public override string GetScalarValue()
         {
             var scalarValue = _node.GetValue<object>();
-            return Convert.ToString(scalarValue, CultureInfo.InvariantCulture)
-                ?? throw new OverlayReaderException($"Expected a value at {Context.GetLocation()}.");
+            return Convert.ToString(scalarValue, CultureInfo.InvariantCulture)!;
         }
 
         public override T GetScalarValue<T>()

--- a/src/lib/Reader/ParsingContext.cs
+++ b/src/lib/Reader/ParsingContext.cs
@@ -259,12 +259,22 @@ public class ParsingContext
 
     private void ValidateRequiredFields(OverlayDocument doc, string version)
     {
-        if (OverlayV1Version.Equals(version, StringComparison.OrdinalIgnoreCase) && RootNode is not null)
+        if (!OverlayV1Version.Equals(version, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (RootNode is not null)
         {
             if (doc.Actions == null)
+            {
                 RootNode.Context.Diagnostic.Errors.Add(new OpenApiError("", $"Actions is a REQUIRED field at {RootNode.Context.GetLocation()}"));
+            }
+
             if (doc.Info == null)
+            {
                 RootNode.Context.Diagnostic.Errors.Add(new OpenApiError("", $"Info is a REQUIRED field at {RootNode.Context.GetLocation()}"));
+            }
         }
     }
 

--- a/src/lib/Reader/V1/OverlayV1Deserializer.cs
+++ b/src/lib/Reader/V1/OverlayV1Deserializer.cs
@@ -5,16 +5,11 @@ namespace BinkyLabs.OpenApi.Overlays.Reader.V1;
 internal static partial class OverlayV1Deserializer
 {
     internal static void ParseMap<T>(
-        MapNode? mapNode,
+        MapNode mapNode,
         T domainObject,
         FixedFieldMap<T> fixedFieldMap,
         PatternFieldMap<T> patternFieldMap)
     {
-        if (mapNode == null)
-        {
-            return;
-        }
-
         foreach (var propertyNode in mapNode)
         {
             propertyNode.ParseField(domainObject, fixedFieldMap, patternFieldMap);

--- a/tests/lib/Reader/JsonNodeHelperTests.cs
+++ b/tests/lib/Reader/JsonNodeHelperTests.cs
@@ -1,0 +1,33 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+using Microsoft.OpenApi;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader;
+
+public class JsonNodeHelperTests
+{
+    [Fact]
+    public void GetScalarValue_OnJsonValue_ReturnsString()
+    {
+        JsonNode node = JsonValue.Create("hello")!;
+        Assert.Equal("hello", node.GetScalarValue());
+    }
+
+    [Fact]
+    public void GetScalarValue_OnJsonValueNumber_ReturnsString()
+    {
+        JsonNode node = JsonValue.Create(42)!;
+        Assert.Equal("42", node.GetScalarValue());
+    }
+
+    [Fact]
+    public void GetScalarValue_OnJsonObject_Throws()
+    {
+        JsonNode node = new JsonObject();
+        Assert.Throws<OpenApiException>(() => node.GetScalarValue());
+    }
+}

--- a/tests/lib/Reader/OverlayReaderSettingsTests.cs
+++ b/tests/lib/Reader/OverlayReaderSettingsTests.cs
@@ -1,0 +1,149 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Reader;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader;
+
+public class OverlayReaderSettingsTests
+{
+    [Fact]
+    public void Default_HttpClient_IsLazyShared()
+    {
+        var settings = new OverlayReaderSettings();
+        Assert.NotNull(settings.HttpClient);
+        Assert.Same(settings.HttpClient, settings.HttpClient);
+    }
+
+    [Fact]
+    public void HttpClient_CanBeInitialized()
+    {
+        using var http = new HttpClient();
+        var settings = new OverlayReaderSettings { HttpClient = http };
+        Assert.Same(http, settings.HttpClient);
+    }
+
+    [Fact]
+    public void Readers_DefaultHasJsonAndYaml()
+    {
+        var settings = new OverlayReaderSettings();
+        Assert.True(settings.Readers.ContainsKey(OpenApiConstants.Json));
+        Assert.True(settings.Readers.ContainsKey(OpenApiConstants.Yaml));
+    }
+
+    [Fact]
+    public void Readers_Init_CopiesNonOrdinalIgnoreCaseDictionary()
+    {
+        var dict = new Dictionary<string, IOverlayReader>(StringComparer.Ordinal)
+        {
+            { "json", new OverlayJsonReader() }
+        };
+        var settings = new OverlayReaderSettings { Readers = dict };
+
+        Assert.True(settings.Readers.ContainsKey("JSON"));
+    }
+
+    [Fact]
+    public void Readers_Init_KeepsOrdinalIgnoreCaseDictionary()
+    {
+        var dict = new Dictionary<string, IOverlayReader>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "json", new OverlayJsonReader() }
+        };
+        var settings = new OverlayReaderSettings { Readers = dict };
+
+        Assert.Same(dict, settings.Readers);
+    }
+
+    [Fact]
+    public void Readers_Init_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new OverlayReaderSettings { Readers = null! });
+    }
+
+    [Fact]
+    public void TryAddReader_AddsNewFormat()
+    {
+        var settings = new OverlayReaderSettings();
+        var added = settings.TryAddReader("xml", new OverlayJsonReader());
+        Assert.True(added);
+        Assert.True(settings.Readers.ContainsKey("xml"));
+    }
+
+    [Fact]
+    public void TryAddReader_ReturnsFalseWhenExists()
+    {
+        var settings = new OverlayReaderSettings();
+        var added = settings.TryAddReader(OpenApiConstants.Json, new OverlayJsonReader());
+        Assert.False(added);
+    }
+
+    [Fact]
+    public void TryAddReader_ThrowsOnNullArgs()
+    {
+        var settings = new OverlayReaderSettings();
+        Assert.Throws<ArgumentException>(() => settings.TryAddReader("", new OverlayJsonReader()));
+        Assert.Throws<ArgumentNullException>(() => settings.TryAddReader("xml", null!));
+    }
+
+    [Fact]
+    public void AddJsonReader_NoOpWhenAlreadyPresent()
+    {
+        var settings = new OverlayReaderSettings();
+        settings.AddJsonReader();
+        Assert.True(settings.Readers.ContainsKey(OpenApiConstants.Json));
+    }
+
+    [Fact]
+    public void GetReader_ReturnsRegisteredReader()
+    {
+        var settings = new OverlayReaderSettings();
+        var reader = (IOverlayReader)typeof(OverlayReaderSettings)
+            .GetMethod("GetReader", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(settings, [OpenApiConstants.Json])!;
+        Assert.NotNull(reader);
+    }
+
+    [Fact]
+    public void GetReader_ThrowsForUnknownFormat()
+    {
+        var settings = new OverlayReaderSettings();
+        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => typeof(OverlayReaderSettings)
+            .GetMethod("GetReader", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(settings, ["unknown-format"]));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void GetReader_ThrowsOnEmptyFormat()
+    {
+        var settings = new OverlayReaderSettings();
+        var ex = Assert.Throws<System.Reflection.TargetInvocationException>(() => typeof(OverlayReaderSettings)
+            .GetMethod("GetReader", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(settings, [""]));
+        Assert.IsType<ArgumentException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void ExtensionParsers_CanBeAssigned()
+    {
+        var settings = new OverlayReaderSettings
+        {
+            ExtensionParsers = new Dictionary<string, Func<JsonNode, OverlaySpecVersion, IOverlayExtension>>
+            {
+                ["x-foo"] = (n, _) => new JsonNodeExtension(n)
+            }
+        };
+        Assert.NotNull(settings.ExtensionParsers);
+        Assert.True(settings.ExtensionParsers!.ContainsKey("x-foo"));
+    }
+
+    [Fact]
+    public void OpenApiSettings_IsSettable()
+    {
+        var settings = new OverlayReaderSettings { OpenApiSettings = new OpenApiReaderSettings { BaseUrl = new Uri("https://example.com/") } };
+        Assert.Equal(new Uri("https://example.com/"), settings.OpenApiSettings.BaseUrl);
+    }
+}

--- a/tests/lib/Reader/ParseNodes/MapNodeAdditionalTests.cs
+++ b/tests/lib/Reader/ParseNodes/MapNodeAdditionalTests.cs
@@ -1,0 +1,103 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader.ParseNodes;
+
+public class MapNodeAdditionalTests
+{
+    private static MapNode MakeMap(string json)
+    {
+        var node = JsonNode.Parse(json)!;
+        return new MapNode(new ParsingContext(new OverlayDiagnostic()), node);
+    }
+
+    [Fact]
+    public void CreateMap_NonObjectValue_UsesDefault()
+    {
+        var map = MakeMap("""{ "a": "scalar", "b": { "k": "v" } }""");
+        var result = map.CreateMap(static n => n.GetRaw());
+
+        Assert.Equal(2, result.Count);
+        Assert.Null(result["a"]);
+        Assert.NotNull(result["b"]);
+    }
+
+    [Fact]
+    public void CreateSimpleMap_NonScalarValue_Throws()
+    {
+        var map = MakeMap("""{ "a": { "nested": true } }""");
+        Assert.Throws<OverlayReaderException>(() => map.CreateSimpleMap(static v => v.GetScalarValue()));
+    }
+
+    [Fact]
+    public void CreateArrayMap_NonArrayValue_Throws()
+    {
+        var map = MakeMap("""{ "a": "not-array" }""");
+        Assert.Throws<OverlayReaderException>(() => map.CreateArrayMap(static v => v.GetScalarValue()));
+    }
+
+    [Fact]
+    public void CreateArrayMap_ArrayValue_Succeeds()
+    {
+        var map = MakeMap("""{ "a": ["x", "y"] }""");
+        var result = map.CreateArrayMap(static v => v.GetScalarValue());
+
+        Assert.Single(result);
+        Assert.Equal(2, result["a"].Count);
+    }
+
+    [Fact]
+    public void GetScalarValue_NonScalarChild_Throws()
+    {
+        var map = MakeMap("""{ "a": { "nested": true } }""");
+        var key = new ValueNode(new ParsingContext(new OverlayDiagnostic()), JsonValue.Create("a")!);
+        Assert.Throws<OverlayReaderException>(() => map.GetScalarValue(key));
+    }
+
+    [Fact]
+    public void Reference_Identifier_Summary_Description_Found()
+    {
+        var map = MakeMap("""{ "$ref": "#/x", "$id": "id1", "summary": "s", "description": "d" }""");
+
+        Assert.Equal("#/x", map.GetReferencePointer());
+        Assert.Equal("id1", map.GetJsonSchemaIdentifier());
+        Assert.Equal("s", map.GetSummaryValue());
+        Assert.Equal("d", map.GetDescriptionValue());
+    }
+
+    [Fact]
+    public void Reference_Identifier_Summary_Description_NotFound()
+    {
+        var map = MakeMap("""{ "k": "v" }""");
+
+        Assert.Null(map.GetReferencePointer());
+        Assert.Null(map.GetJsonSchemaIdentifier());
+        Assert.Null(map.GetSummaryValue());
+        Assert.Null(map.GetDescriptionValue());
+    }
+
+    [Fact]
+    public void Indexer_MissingKey_ReturnsNull()
+    {
+        var map = MakeMap("""{ "a": "v" }""");
+        Assert.Null(map["missing"]);
+    }
+
+    [Fact]
+    public void Indexer_ExistingKey_ReturnsPropertyNode()
+    {
+        var map = MakeMap("""{ "a": "v" }""");
+        Assert.NotNull(map["a"]);
+    }
+
+    [Fact]
+    public void Constructor_NonObject_Throws()
+    {
+        var ctx = new ParsingContext(new OverlayDiagnostic());
+        var node = JsonNode.Parse("\"scalar\"")!;
+        Assert.Throws<OverlayReaderException>(() => new MapNode(ctx, node));
+    }
+}

--- a/tests/lib/Reader/ParseNodes/MapNodeNullValueTests.cs
+++ b/tests/lib/Reader/ParseNodes/MapNodeNullValueTests.cs
@@ -1,0 +1,51 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader.ParseNodes;
+
+public class MapNodeNullValueTests
+{
+    private static MapNode MakeMap(string json)
+    {
+        var node = JsonNode.Parse(json)!;
+        return new MapNode(new ParsingContext(new OverlayDiagnostic()), node);
+    }
+
+    [Fact]
+    public void GetReferencePointer_NullValue_ReturnsNull()
+    {
+        var map = MakeMap("""{ "$ref": null }""");
+        Assert.Null(map.GetReferencePointer());
+    }
+
+    [Fact]
+    public void GetJsonSchemaIdentifier_NullValue_ReturnsNull()
+    {
+        var map = MakeMap("""{ "$id": null }""");
+        Assert.Null(map.GetJsonSchemaIdentifier());
+    }
+
+    [Fact]
+    public void GetSummaryValue_NullValue_ReturnsNull()
+    {
+        var map = MakeMap("""{ "summary": null }""");
+        Assert.Null(map.GetSummaryValue());
+    }
+
+    [Fact]
+    public void GetDescriptionValue_NullValue_ReturnsNull()
+    {
+        var map = MakeMap("""{ "description": null }""");
+        Assert.Null(map.GetDescriptionValue());
+    }
+
+    [Fact]
+    public void Indexer_NullValue_ReturnsNull()
+    {
+        var map = MakeMap("""{ "k": null }""");
+        Assert.Null(map["k"]);
+    }
+}

--- a/tests/lib/Reader/ParseNodes/ParseNodeTests.cs
+++ b/tests/lib/Reader/ParseNodes/ParseNodeTests.cs
@@ -1,0 +1,418 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+using Microsoft.OpenApi;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader.ParseNodes;
+
+public class ParseNodeTests
+{
+    private static ParsingContext Ctx() => new(new OverlayDiagnostic());
+
+    [Fact]
+    public void Create_JsonArray_ReturnsListNode()
+    {
+        var node = ParseNode.Create(Ctx(), JsonNode.Parse("[]")!);
+        Assert.IsType<ListNode>(node);
+    }
+
+    [Fact]
+    public void Create_JsonObject_ReturnsMapNode()
+    {
+        var node = ParseNode.Create(Ctx(), JsonNode.Parse("{}")!);
+        Assert.IsType<MapNode>(node);
+    }
+
+    [Fact]
+    public void Create_JsonValue_ReturnsValueNode()
+    {
+        var node = ParseNode.Create(Ctx(), JsonValue.Create("hi")!);
+        Assert.IsType<ValueNode>(node);
+    }
+
+    [Fact]
+    public void CheckMapNode_OnNonMap_Throws()
+    {
+        var node = ParseNode.Create(Ctx(), JsonNode.Parse("[]")!);
+        Assert.Throws<OverlayReaderException>(() => node.CheckMapNode("foo"));
+    }
+
+    [Fact]
+    public void CheckMapNode_OnMap_ReturnsMap()
+    {
+        var node = ParseNode.Create(Ctx(), JsonNode.Parse("{}")!);
+        Assert.NotNull(node.CheckMapNode("foo"));
+    }
+
+    [Fact]
+    public void ValueNode_GetScalarValue_ReturnsString()
+    {
+        var node = new ValueNode(Ctx(), JsonValue.Create("abc")!);
+        Assert.Equal("abc", node.GetScalarValue());
+    }
+
+    [Fact]
+    public void ValueNode_CreateAny_ReturnsNode()
+    {
+        var val = JsonValue.Create("abc")!;
+        var node = new ValueNode(Ctx(), val);
+        Assert.Same(val, node.CreateAny());
+    }
+
+    [Fact]
+    public void ValueNode_Construct_FromNonValue_Throws()
+    {
+        Assert.Throws<OverlayReaderException>(() => new ValueNode(Ctx(), JsonNode.Parse("{}")!));
+    }
+
+    [Fact]
+    public void ListNode_CreateList_ProjectsObjects()
+    {
+        var list = new ListNode(Ctx(), JsonNode.Parse("""[{"a":1},{"b":2}]""")!.AsArray());
+        var result = list.CreateList(m => m);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ListNode_CreateSimpleList_ProjectsValues()
+    {
+        var list = new ListNode(Ctx(), JsonNode.Parse("""["a","b"]""")!.AsArray());
+        var result = list.CreateSimpleList(v => v.GetScalarValue());
+        Assert.Equal(["a", "b"], result);
+    }
+
+    [Fact]
+    public void ListNode_CreateListOfAny_ReturnsItems()
+    {
+        var list = new ListNode(Ctx(), JsonNode.Parse("""[1,2,3]""")!.AsArray());
+        var result = list.CreateListOfAny();
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public void ListNode_CreateAny_ReturnsArray()
+    {
+        var arr = JsonNode.Parse("[1,2]")!.AsArray();
+        var list = new ListNode(Ctx(), arr);
+        Assert.Same(arr, list.CreateAny());
+    }
+
+    [Fact]
+    public void ListNode_Enumerate_ReturnsParseNodes()
+    {
+        var list = new ListNode(Ctx(), JsonNode.Parse("[1,2]")!.AsArray());
+        var items = list.ToList();
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.IsType<ValueNode>(i));
+    }
+
+    [Fact]
+    public void MapNode_Construct_FromNonObject_Throws()
+    {
+        Assert.Throws<OverlayReaderException>(() => new MapNode(Ctx(), JsonNode.Parse("[]")!));
+    }
+
+    [Fact]
+    public void MapNode_Indexer_ReturnsPropertyNodeOrNull()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":1}""")!);
+        Assert.NotNull(map["a"]);
+        Assert.Null(map["missing"]);
+    }
+
+    [Fact]
+    public void MapNode_CreateMap_BuildsDictionary()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":{"x":1},"b":{"y":2}}""")!);
+        var result = map.CreateMap(m => m.GetReferencePointer() ?? "no-ref");
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void MapNode_CreateMap_NonObjectValueProducesDefault()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a": 1}""")!);
+        var result = map.CreateMap<object?>(m => m);
+        Assert.Null(result["a"]);
+    }
+
+    [Fact]
+    public void MapNode_CreateSimpleMap_BuildsDictionary()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":"x","b":"y"}""")!);
+        var result = map.CreateSimpleMap(v => v.GetScalarValue());
+        Assert.Equal("x", result["a"]);
+        Assert.Equal("y", result["b"]);
+    }
+
+    [Fact]
+    public void MapNode_CreateSimpleMap_NonScalar_Throws()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":{}}""")!);
+        Assert.Throws<OverlayReaderException>(() => map.CreateSimpleMap(v => v.GetScalarValue()));
+    }
+
+    [Fact]
+    public void MapNode_CreateArrayMap_BuildsDictionary()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":["x","y"],"b":["z"]}""")!);
+        var result = map.CreateArrayMap(v => v.GetScalarValue());
+        Assert.Equal(2, result["a"].Count);
+        Assert.Single(result["b"]);
+    }
+
+    [Fact]
+    public void MapNode_CreateArrayMap_NonArray_Throws()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":"x"}""")!);
+        Assert.Throws<OverlayReaderException>(() => map.CreateArrayMap(v => v.GetScalarValue()));
+    }
+
+    [Fact]
+    public void MapNode_GetRaw_ReturnsJsonString()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":1}""")!);
+        Assert.Contains("\"a\"", map.GetRaw());
+    }
+
+    [Fact]
+    public void MapNode_GetReferencePointer_ReturnsRefOrNull()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"$ref":"#/a"}""")!);
+        Assert.Equal("#/a", map.GetReferencePointer());
+
+        var no = new MapNode(Ctx(), JsonNode.Parse("""{"x":1}""")!);
+        Assert.Null(no.GetReferencePointer());
+    }
+
+    [Fact]
+    public void MapNode_GetJsonSchemaIdentifier_ReturnsIdOrNull()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"$id":"foo"}""")!);
+        Assert.Equal("foo", map.GetJsonSchemaIdentifier());
+
+        var no = new MapNode(Ctx(), JsonNode.Parse("""{}""")!);
+        Assert.Null(no.GetJsonSchemaIdentifier());
+    }
+
+    [Fact]
+    public void MapNode_GetSummaryAndDescription_ReturnsValuesOrNull()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"summary":"s","description":"d"}""")!);
+        Assert.Equal("s", map.GetSummaryValue());
+        Assert.Equal("d", map.GetDescriptionValue());
+
+        var no = new MapNode(Ctx(), JsonNode.Parse("""{}""")!);
+        Assert.Null(no.GetSummaryValue());
+        Assert.Null(no.GetDescriptionValue());
+    }
+
+    [Fact]
+    public void MapNode_GetScalarValue_ByKey_ReturnsValue()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":"hi"}""")!);
+        var keyNode = new ValueNode(Ctx(), JsonValue.Create("a")!);
+        Assert.Equal("hi", map.GetScalarValue(keyNode));
+    }
+
+    [Fact]
+    public void MapNode_GetScalarValue_NonScalarKey_Throws()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":{}}""")!);
+        var keyNode = new ValueNode(Ctx(), JsonValue.Create("a")!);
+        Assert.Throws<OverlayReaderException>(() => map.GetScalarValue(keyNode));
+    }
+
+    [Fact]
+    public void MapNode_CreateAny_ReturnsJsonObject()
+    {
+        var obj = JsonNode.Parse("""{"a":1}""")!.AsObject();
+        var map = new MapNode(Ctx(), obj);
+        Assert.Same(obj, map.CreateAny());
+    }
+
+    [Fact]
+    public void MapNode_Enumerate_ReturnsProperties()
+    {
+        var map = new MapNode(Ctx(), JsonNode.Parse("""{"a":1,"b":2}""")!);
+        var props = map.ToList();
+        Assert.Equal(2, props.Count);
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_CallsFixedFieldMap()
+    {
+        var propNode = new PropertyNode(Ctx(), "foo", JsonValue.Create("bar")!);
+        var holder = new Holder();
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>
+        {
+            ["foo"] = (h, v) => h.Value = v.GetScalarValue()
+        };
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>();
+
+        propNode.ParseField(holder, fixedFields, patternFields);
+
+        Assert.Equal("bar", holder.Value);
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_CallsPatternFieldMap()
+    {
+        var propNode = new PropertyNode(Ctx(), "x-foo", JsonValue.Create("bar")!);
+        var holder = new Holder();
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>();
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>
+        {
+            [k => k.StartsWith("x-")] = (h, k, v) => h.Value = $"{k}={v.GetScalarValue()}"
+        };
+
+        propNode.ParseField(holder, fixedFields, patternFields);
+
+        Assert.Equal("x-foo=bar", holder.Value);
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_UnknownField_AddsDiagnostic()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "unknown", JsonValue.Create("bar")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>();
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>();
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("unknown is not a valid property"));
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_SchemaField_IsIgnored()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "$schema", JsonValue.Create("https://example.com/schema")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>();
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>();
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Empty(ctx.Diagnostic.Errors);
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_OverlayReaderException_AddsDiagnostic()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "foo", JsonValue.Create("bar")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>
+        {
+            ["foo"] = (_, _) => throw new OverlayReaderException("reader-err")
+        };
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>();
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("reader-err"));
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_OpenApiException_AddsDiagnostic()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "foo", JsonValue.Create("bar")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>
+        {
+            ["foo"] = (_, _) => throw new OpenApiException("openapi-err")
+        };
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>();
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("openapi-err"));
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_PatternThrowsOverlayReaderException_AddsDiagnostic()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "x-foo", JsonValue.Create("bar")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>();
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>
+        {
+            [k => k.StartsWith("x-")] = (_, _, _) => throw new OverlayReaderException("pattern-err")
+        };
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("pattern-err"));
+    }
+
+    [Fact]
+    public void PropertyNode_ParseField_PatternThrowsOpenApiException_AddsDiagnostic()
+    {
+        var ctx = Ctx();
+        var propNode = new PropertyNode(ctx, "x-foo", JsonValue.Create("bar")!);
+        var fixedFields = new Dictionary<string, Action<Holder, ParseNode>>();
+        var patternFields = new Dictionary<Func<string, bool>, Action<Holder, string, ParseNode>>
+        {
+            [k => k.StartsWith("x-")] = (_, _, _) => throw new OpenApiException("pattern-openapi-err")
+        };
+
+        propNode.ParseField(new Holder(), fixedFields, patternFields);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("pattern-openapi-err"));
+    }
+
+    [Fact]
+    public void PropertyNode_CreateAny_Throws()
+    {
+        var propNode = new PropertyNode(Ctx(), "foo", JsonValue.Create("bar")!);
+        Assert.Throws<NotImplementedException>(() => propNode.CreateAny());
+    }
+
+    [Fact]
+    public void RootNode_Find_ReturnsParseNodeOrNull()
+    {
+        var root = new RootNode(Ctx(), JsonNode.Parse("""{"a":{"b":"c"}}""")!);
+        var node = root.Find(new JsonPointer("/a/b"));
+        Assert.NotNull(node);
+        Assert.IsType<ValueNode>(node);
+
+        Assert.Null(root.Find(new JsonPointer("/missing")));
+    }
+
+    [Fact]
+    public void RootNode_GetMap_ReturnsMapNode()
+    {
+        var root = new RootNode(Ctx(), JsonNode.Parse("""{"a":1}""")!);
+        var map = root.GetMap();
+        Assert.NotNull(map);
+        Assert.NotNull(map["a"]);
+    }
+
+    [Fact]
+    public void ParseNode_VirtualMethods_ThrowFromValueNode()
+    {
+        ParseNode v = new ValueNode(Ctx(), JsonValue.Create("x")!);
+        Assert.Throws<OverlayReaderException>(() => v.CreateList<int>(_ => 0));
+        Assert.Throws<OverlayReaderException>(() => v.CreateMap<int>(_ => 0));
+        Assert.Throws<OverlayReaderException>(() => v.CreateSimpleList<int>(_ => 0));
+        Assert.Throws<OverlayReaderException>(() => v.CreateSimpleMap<int>(_ => 0));
+        Assert.Throws<OverlayReaderException>(() => v.GetRaw());
+        Assert.Throws<OverlayReaderException>(() => v.CreateListOfAny());
+        Assert.Throws<OverlayReaderException>(() => v.CreateArrayMap<int>(_ => 0));
+    }
+
+    [Fact]
+    public void ParseNode_VirtualMethods_GetScalarValue_OnMap_Throws()
+    {
+        ParseNode m = new MapNode(Ctx(), JsonNode.Parse("{}")!);
+        Assert.Throws<OverlayReaderException>(() => m.GetScalarValue());
+    }
+
+    private class Holder
+    {
+        public string? Value { get; set; }
+    }
+}

--- a/tests/lib/Reader/ParsingContextTests.cs
+++ b/tests/lib/Reader/ParsingContextTests.cs
@@ -1,0 +1,198 @@
+// Licensed under the MIT license.
+
+using System.Text.Json.Nodes;
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+using Microsoft.OpenApi;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader;
+
+public class ParsingContextTests
+{
+    private static ParsingContext CreateContext() => new(new OverlayDiagnostic());
+
+    [Fact]
+    public void GetFromTempStorage_NoScope_ReturnsDefaultWhenMissing()
+    {
+        var ctx = CreateContext();
+
+        Assert.Null(ctx.GetFromTempStorage<string>("missing"));
+    }
+
+    [Fact]
+    public void SetTempStorage_NoScope_StoresAndRetrieves()
+    {
+        var ctx = CreateContext();
+        ctx.SetTempStorage("key", "value");
+
+        Assert.Equal("value", ctx.GetFromTempStorage<string>("key"));
+    }
+
+    [Fact]
+    public void SetTempStorage_NoScopeNullValue_RemovesKey()
+    {
+        var ctx = CreateContext();
+        ctx.SetTempStorage("key", "value");
+        ctx.SetTempStorage("key", null);
+
+        Assert.Null(ctx.GetFromTempStorage<string>("key"));
+    }
+
+    [Fact]
+    public void SetTempStorage_WithScope_StoresAndRetrieves()
+    {
+        var ctx = CreateContext();
+        var scope = new object();
+        ctx.SetTempStorage("key", "value", scope);
+
+        Assert.Equal("value", ctx.GetFromTempStorage<string>("key", scope));
+    }
+
+    [Fact]
+    public void GetFromTempStorage_UnknownScope_ReturnsDefault()
+    {
+        var ctx = CreateContext();
+        var scope = new object();
+
+        Assert.Null(ctx.GetFromTempStorage<string>("key", scope));
+    }
+
+    [Fact]
+    public void SetTempStorage_WithScopeNullValue_RemovesKey()
+    {
+        var ctx = CreateContext();
+        var scope = new object();
+        ctx.SetTempStorage("key", "value", scope);
+        ctx.SetTempStorage("key", null, scope);
+
+        Assert.Null(ctx.GetFromTempStorage<string>("key", scope));
+    }
+
+    [Fact]
+    public void StartObject_EndObject_AffectsLocation()
+    {
+        var ctx = CreateContext();
+        Assert.Equal("#/", ctx.GetLocation());
+        ctx.StartObject("foo");
+        ctx.StartObject("bar/baz~qux");
+        Assert.Equal("#/foo/bar~1baz~0qux", ctx.GetLocation());
+        ctx.EndObject();
+        Assert.Equal("#/foo", ctx.GetLocation());
+        ctx.EndObject();
+        Assert.Equal("#/", ctx.GetLocation());
+    }
+
+    [Fact]
+    public void PushLoop_AddsKey_ReturnsTrue()
+    {
+        var ctx = CreateContext();
+        Assert.True(ctx.PushLoop("loop1", "a"));
+        Assert.True(ctx.PushLoop("loop1", "b"));
+    }
+
+    [Fact]
+    public void PushLoop_DuplicateKey_ReturnsFalse()
+    {
+        var ctx = CreateContext();
+        ctx.PushLoop("loop1", "a");
+        Assert.False(ctx.PushLoop("loop1", "a"));
+    }
+
+    [Fact]
+    public void PopLoop_RemovesTop()
+    {
+        var ctx = CreateContext();
+        ctx.PushLoop("loop1", "a");
+        ctx.PushLoop("loop1", "b");
+        ctx.PopLoop("loop1");
+        Assert.True(ctx.PushLoop("loop1", "b"));
+    }
+
+    [Fact]
+    public void PopLoop_EmptyStack_DoesNothing()
+    {
+        var ctx = CreateContext();
+        ctx.PushLoop("loop1", "a");
+        ctx.PopLoop("loop1");
+        ctx.PopLoop("loop1");
+    }
+
+    [Fact]
+    public void Parse_ValidOverlayDocument_ReturnsDocument()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""
+            {
+              "overlay": "1.0.0",
+              "info": { "title": "T", "version": "1" },
+              "actions": []
+            }
+            """)!;
+
+        var doc = ctx.Parse(jsonNode);
+
+        Assert.NotNull(doc);
+        Assert.NotNull(doc.Info);
+        Assert.Equal(OverlaySpecVersion.Overlay1_0, ctx.Diagnostic.SpecificationVersion);
+    }
+
+    [Fact]
+    public void Parse_MissingRequiredFields_AddsDiagnosticErrors()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""
+            {
+              "overlay": "1.0.0"
+            }
+            """)!;
+
+        ctx.Parse(jsonNode);
+
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("Info is a REQUIRED field"));
+        Assert.Contains(ctx.Diagnostic.Errors, e => e.Message.Contains("Actions is a REQUIRED field"));
+    }
+
+    [Fact]
+    public void Parse_MissingVersion_ThrowsOpenApiException()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""
+            { "info": { "title": "T" } }
+            """)!;
+
+        Assert.Throws<OpenApiException>(() => ctx.Parse(jsonNode));
+    }
+
+    [Fact]
+    public void Parse_UnsupportedVersion_ThrowsUnsupportedSpecException()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""
+            { "overlay": "9.9.9", "info": { "title": "T", "version": "1" }, "actions": [] }
+            """)!;
+
+        Assert.Throws<OpenApiUnsupportedSpecVersionException>(() => ctx.Parse(jsonNode));
+    }
+
+    [Fact]
+    public void ParseFragment_Overlay1_0_ReturnsElement()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""{ "title": "T", "version": "1" }""")!;
+
+        var info = ctx.ParseFragment<OverlayInfo>(jsonNode, OverlaySpecVersion.Overlay1_0);
+
+        Assert.NotNull(info);
+        Assert.Equal("T", info!.Title);
+    }
+
+    [Fact]
+    public void ParseFragment_UnsupportedVersion_Throws()
+    {
+        var ctx = CreateContext();
+        var jsonNode = JsonNode.Parse("""{ "title": "T" }""")!;
+
+        Assert.Throws<OpenApiUnsupportedSpecVersionException>(() => ctx.ParseFragment<OverlayInfo>(jsonNode, (OverlaySpecVersion)999));
+    }
+}

--- a/tests/lib/Reader/ReadResultTests.cs
+++ b/tests/lib/Reader/ReadResultTests.cs
@@ -1,0 +1,32 @@
+// Licensed under the MIT license.
+
+using BinkyLabs.OpenApi.Overlays.Reader;
+
+namespace BinkyLabs.OpenApi.Overlays.Tests.Reader;
+
+public class ReadResultTests
+{
+    [Fact]
+    public void Deconstruct_TwoOut_ReturnsDocumentAndDiagnostic()
+    {
+        var doc = new OverlayDocument();
+        var diag = new OverlayDiagnostic();
+        var result = new ReadResult { Document = doc, Diagnostic = diag };
+
+        var (d, di) = result;
+
+        Assert.Same(doc, d);
+        Assert.Same(diag, di);
+    }
+
+    [Fact]
+    public void Deconstruct_OneOut_ReturnsDocument()
+    {
+        var doc = new OverlayDocument();
+        var result = new ReadResult { Document = doc };
+
+        result.Deconstruct(out var d);
+
+        Assert.Same(doc, d);
+    }
+}


### PR DESCRIPTION
## Summary
- replicate parsing infrastructure cleanup from the Arazzo PR for Overlays
- add unit coverage for parse nodes, parsing context, reader settings, JSON node helper, and read result

## Validation
- dotnet test
- dotnet format