### PR TITLE
ci(promote-shipped-apis): check required secrets before running

### DIFF
--- a/.github/workflows/promote-shipped-apis.yml
+++ b/.github/workflows/promote-shipped-apis.yml
@@ -8,7 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
+    steps:
+      - name: Check promote workflow secrets
+        id: check
+        run: echo "has-secrets=${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_APP_ID != '' && secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM != '' }}" >> $GITHUB_OUTPUT
+
   promote-apis:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-secrets == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/promote-shipped-apis.yml
+++ b/.github/workflows/promote-shipped-apis.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:


### PR DESCRIPTION
## Summary`n- add a secrets precheck job to the promote shipped APIs workflow`n- skip the promote job when the required GitHub App secrets are unavailable