### PR TITLE
ci(dotnet): upload GitHub coverage reports

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      code-quality: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v5
         with:
@@ -37,7 +41,14 @@ jobs:
       - name: Pack the project
         run: dotnet pack --configuration Release
       - name: Generate coverage report
-        run: reportgenerator -reporttypes:MarkdownSummary -reports:**/coverage.cobertura.*.xml -targetdir:./reports/coverage
+        run: reportgenerator -reporttypes:"MarkdownSummaryGithub;Cobertura" -reports:**/coverage.cobertura.*.xml -targetdir:./reports/coverage
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: ./reports/coverage/Cobertura.xml
+          language: CSharp
+          label: code-coverage/dotnet
       - uses: actions/upload-artifact@v7
         with:
           name: coverage
@@ -46,9 +57,9 @@ jobs:
         with:
           name: packages
           path: src/*/bin/Release/*.*nupkg
-      - name:  Publish coverage report to GitHub Step Summary
+      - name: Publish coverage report to GitHub Step Summary
         run: |
-           cat reports/coverage/Summary.md >>  $GITHUB_STEP_SUMMARY
+          cat reports/coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
   
   publish-release-to-nuget:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- grant the dotnet workflow the permissions needed for GitHub coverage uploads
- check out the PR head SHA so coverage annotations map to the changed lines
- generate a Cobertura report from the existing coverlet output and upload it with `actions/upload-code-coverage`

## Validation
- dotnet restore
- dotnet format --verify-no-changes
- dotnet build --configuration Release
- dotnet test --configuration Release
