### PR TITLE
ci: skip coverage uploads off default branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Generate coverage report
         run: reportgenerator -reporttypes:"MarkdownSummaryGithub;Cobertura" -reports:**/coverage.cobertura.*.xml -targetdir:./reports/coverage
       - name: Upload coverage report
-        if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+        if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') || (github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch)
         uses: actions/upload-code-coverage@v1
         with:
           file: ./reports/coverage/Cobertura.xml


### PR DESCRIPTION
## Summary
- only upload GitHub code coverage on pull requests from this repository
- allow branch uploads only on the repository default branch
- skip uploads on other branch push and workflow_dispatch runs to avoid post-merge 400 errors