### PR TITLE
feat(tool): add overlay validate command

### DIFF
--- a/src/tool/OverlayCliApp.cs
+++ b/src/tool/OverlayCliApp.cs
@@ -26,6 +26,8 @@ internal static class OverlayCliApp
         rootCommand.Add(applyCommand);
         var applyAndNormalizeCommand = CreateApplyCommand("apply-and-normalize", "Apply one or more overlays to an OpenAPI document, and normalize the output with OpenAPI.net", ApplyOverlaysAndNormalizeAsync);
         rootCommand.Add(applyAndNormalizeCommand);
+        var validateCommand = CreateValidateCommand();
+        rootCommand.Add(validateCommand);
         return await rootCommand.Parse(args).InvokeAsync(cancellationToken: cancellationToken);
     }
 
@@ -64,6 +66,39 @@ internal static class OverlayCliApp
         var strictOption = new Option<bool>("--strict") { Description = "Treat targets that match zero nodes as errors instead of warnings" };
         strictOption.Aliases.Add("-s");
         return strictOption;
+    }
+
+    private static Option<bool> CreateWarningsAsErrorsOption()
+    {
+        var warningsAsErrorsOption = new Option<bool>("--warnings-as-errors") { Description = "Treat warnings as errors" };
+        warningsAsErrorsOption.Aliases.Add("--treat-warnings-as-errors");
+        return warningsAsErrorsOption;
+    }
+
+    private static Command CreateValidateCommand()
+    {
+        var validateCommand = new Command("validate", "Validate an Overlay document and report errors and warnings");
+        var overlayArgument = new Argument<string>("overlay") { Description = "Path or URL to the Overlay document" };
+        var warningsAsErrorsOption = CreateWarningsAsErrorsOption();
+
+        validateCommand.Add(overlayArgument);
+        validateCommand.Add(warningsAsErrorsOption);
+
+        validateCommand.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var overlay = parseResult.GetValue(overlayArgument);
+            var warningsAsErrors = parseResult.GetValue(warningsAsErrorsOption);
+
+            if (string.IsNullOrEmpty(overlay))
+            {
+                await Console.Error.WriteLineAsync("Error: Overlay argument is required.");
+                return 1;
+            }
+
+            return await ValidateOverlayAsync(overlay, warningsAsErrors, cancellationToken).ConfigureAwait(false);
+        });
+
+        return validateCommand;
     }
 
     private static Command CreateApplyCommand(string name, string description, Func<string, string[], string, bool, CancellationToken, Task> applyAsync)
@@ -111,6 +146,75 @@ internal static class OverlayCliApp
         });
 
         return applyCommand;
+    }
+
+    private static async Task<int> ValidateOverlayAsync(string overlay, bool warningsAsErrors, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Console.Out.WriteLineAsync($"Validating overlay: {overlay}");
+
+            if (!IsHttpUrl(overlay) && !File.Exists(overlay))
+            {
+                await Console.Error.WriteLineAsync($"Error: Overlay file '{overlay}' does not exist.");
+                return 1;
+            }
+
+            var (_, diagnostic) = await OverlayDocument.LoadFromUrlAsync(overlay, token: cancellationToken).ConfigureAwait(false);
+            diagnostic ??= new OverlayDiagnostic();
+
+            DisplayDiagnostics("Errors", diagnostic.Errors, Console.Error);
+            DisplayDiagnostics("Warnings", diagnostic.Warnings, warningsAsErrors ? Console.Error : Console.Out);
+
+            if (diagnostic.Errors.Count > 0)
+            {
+                return 1;
+            }
+
+            if (warningsAsErrors && diagnostic.Warnings.Count > 0)
+            {
+                await Console.Error.WriteLineAsync("Warnings were treated as errors.");
+                return 1;
+            }
+
+            await Console.Out.WriteLineAsync("Overlay document is valid.");
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            await Console.Out.WriteLineAsync("Operation was cancelled.");
+            return 130;
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static bool IsHttpUrl(string value) =>
+        value.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+        value.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+
+    private static void DisplayDiagnostics(string title, IList<OpenApiError> diagnostics, TextWriter writer)
+    {
+        if (diagnostics.Count == 0)
+        {
+            return;
+        }
+
+        writer.WriteLine($"{title}:");
+        foreach (var diagnostic in diagnostics)
+        {
+            writer.WriteLine($"  - {FormatDiagnostic(diagnostic)}");
+        }
+    }
+
+    private static string FormatDiagnostic(OpenApiError diagnostic)
+    {
+        return string.IsNullOrEmpty(diagnostic.Pointer) ?
+            diagnostic.Message :
+            $"{diagnostic.Pointer}: {diagnostic.Message}";
     }
 
     private static async Task HandleCommandAsync(

--- a/src/tool/OverlayCliApp.cs
+++ b/src/tool/OverlayCliApp.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.YamlReader;
 
+using SharpYaml;
 using SharpYaml.Serialization;
 
 namespace BinkyLabs.OpenApi.Overlays.Cli;

--- a/src/tool/OverlayCliApp.cs
+++ b/src/tool/OverlayCliApp.cs
@@ -71,7 +71,6 @@ internal static class OverlayCliApp
     private static Option<bool> CreateWarningsAsErrorsOption()
     {
         var warningsAsErrorsOption = new Option<bool>("--warnings-as-errors") { Description = "Treat warnings as errors" };
-        warningsAsErrorsOption.Aliases.Add("--treat-warnings-as-errors");
         return warningsAsErrorsOption;
     }
 

--- a/src/tool/OverlayCliApp.cs
+++ b/src/tool/OverlayCliApp.cs
@@ -184,7 +184,27 @@ internal static class OverlayCliApp
             await Console.Out.WriteLineAsync("Operation was cancelled.");
             return 130;
         }
-        catch (Exception ex)
+        catch (UnauthorizedAccessException ex)
+        {
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
+            return 1;
+        }
+        catch (IOException ex)
+        {
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
+            return 1;
+        }
+        catch (OpenApiReaderException ex)
+        {
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
+            return 1;
+        }
+        catch (JsonException ex)
+        {
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
+            return 1;
+        }
+        catch (YamlException ex)
         {
             await Console.Error.WriteLineAsync($"Error: {ex.Message}");
             return 1;

--- a/src/tool/README.md
+++ b/src/tool/README.md
@@ -20,6 +20,20 @@ clio apply pathOrUrlToInputDescription --overlay pathOrUrlToOverlay -out pathFor
 
 > Note: the overlay argument can be specified multiple times, the order matters.
 
+### Validate an overlay
+
+The validate command loads an Overlay document and prints any errors or warnings.
+
+```shell
+clio validate pathOrUrlToOverlay
+```
+
+Use `--warnings-as-errors` to return an error exit code when warnings are present.
+
+```shell
+clio validate pathOrUrlToOverlay --warnings-as-errors
+```
+
 ### Apply and normalize
 
 The apply command applies the overlay actions to an OpenAPI description and normalizes the description based on OpenAPI.net rules and fields ordering.

--- a/tests/tool/OverlayCliAppTests.cs
+++ b/tests/tool/OverlayCliAppTests.cs
@@ -17,14 +17,14 @@ public sealed class OverlayCliAppTests : IDisposable
 {
     private const string jsonExtension = ".json";
     private const string yamlExtension = ".yaml";
-    private readonly string _tempInputFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
-    private readonly string _tempOverlayFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
-    private readonly string _tempInvalidOverlayFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
-    private readonly string _tempOutputFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
+    private readonly string _tempInputFileJson = Path.Join(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
+    private readonly string _tempOverlayFileJson = Path.Join(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
+    private readonly string _tempInvalidOverlayFileJson = Path.Join(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
+    private readonly string _tempOutputFileJson = Path.Join(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
 
-    private readonly string _tempInputFileYaml = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
-    private readonly string _tempOverlayFileYaml = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
-    private readonly string _tempOutputFileYaml = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
+    private readonly string _tempInputFileYaml = Path.Join(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
+    private readonly string _tempOverlayFileYaml = Path.Join(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
+    private readonly string _tempOutputFileYaml = Path.Join(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
 
     private readonly string _validOpenApiJson =
         """

--- a/tests/tool/OverlayCliAppTests.cs
+++ b/tests/tool/OverlayCliAppTests.cs
@@ -19,6 +19,7 @@ public sealed class OverlayCliAppTests : IDisposable
     private const string yamlExtension = ".yaml";
     private readonly string _tempInputFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
     private readonly string _tempOverlayFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
+    private readonly string _tempInvalidOverlayFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
     private readonly string _tempOutputFileJson = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + jsonExtension);
 
     private readonly string _tempInputFileYaml = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + yamlExtension);
@@ -102,10 +103,18 @@ x-custom-extension:
   someProperty: someValue
 """;
 
+    private readonly string _invalidOverlayJson =
+    """
+    {
+        "overlay": "1.0.0"
+    }
+    """;
+
     public OverlayCliAppTests()
     {
         File.WriteAllText(_tempInputFileJson, _validOpenApiJson); // Minimal valid OpenAPI JSON
         File.WriteAllText(_tempOverlayFileJson, _validOverlayJson); // Minimal valid overlay
+        File.WriteAllText(_tempInvalidOverlayFileJson, _invalidOverlayJson); // Invalid overlay missing required fields
         File.WriteAllText(_tempInputFileYaml, _validOpenApiYaml); // Minimal valid OpenAPI YAML
         File.WriteAllText(_tempOverlayFileYaml, _validOverlayYaml); // Minimal valid
     }
@@ -114,6 +123,7 @@ x-custom-extension:
     {
         if (File.Exists(_tempInputFileJson)) File.Delete(_tempInputFileJson);
         if (File.Exists(_tempOverlayFileJson)) File.Delete(_tempOverlayFileJson);
+        if (File.Exists(_tempInvalidOverlayFileJson)) File.Delete(_tempInvalidOverlayFileJson);
         if (File.Exists(_tempOutputFileJson)) File.Delete(_tempOutputFileJson);
         if (File.Exists(_tempInputFileYaml)) File.Delete(_tempInputFileYaml);
         if (File.Exists(_tempOverlayFileYaml)) File.Delete(_tempOverlayFileYaml);
@@ -143,6 +153,27 @@ x-custom-extension:
         Assert.NotNull(openApiDocument);
         Assert.NotNull(diags);
         Assert.Empty(diags.Errors);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidateValidOverlay_ReturnsOK()
+    {
+        var result = await OverlayCliApp.RunAsync(["validate", _tempOverlayFileJson], TestContext.Current.CancellationToken);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidateValidOverlayWithWarningsAsErrors_ReturnsOK()
+    {
+        var result = await OverlayCliApp.RunAsync(["validate", _tempOverlayFileYaml, "--warnings-as-errors"], TestContext.Current.CancellationToken);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidateInvalidOverlay_ReturnsError()
+    {
+        var result = await OverlayCliApp.RunAsync(["validate", _tempInvalidOverlayFileJson], TestContext.Current.CancellationToken);
+        Assert.Equal(1, result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add a new \clio validate\ command that loads Overlay documents and reports errors and warnings
- add \--warnings-as-errors\ / \--treat-warnings-as-errors\ support
- document validate usage and cover it with CLI tests

## Validation
- dotnet test --configuration Release
- dotnet format
- dotnet run --configuration Release --framework net10.0 --project src\\tool\\BinkyLabs.OpenApi.Overlays.Cli.csproj -- validate debug-samples\\overlay.yaml